### PR TITLE
fix: multimodal checkpoints fail under vLLM when max_num_batched_tokens is too small

### DIFF
--- a/interp_engine/facts.py
+++ b/interp_engine/facts.py
@@ -777,6 +777,35 @@ def mandatory_kv_cache_dtype(architectures: Sequence[str] | None) -> str | None:
     return None
 
 
+# A multimodal model whose image tokens attend bidirectionally (Gemma 3, Gemma 4) has chunked
+# multimodal input forced OFF by vLLM, and one whole item must then fit in a single batch or the
+# engine refuses to start: "Chunked MM input disabled but max_tokens_per_mm_item (2496) is larger
+# than max_num_batched_tokens (512)". vLLM raises its own floor for this, but only while defaulting
+# `max_num_batched_tokens`, and clamps the result against `max_model_len` immediately after -- so a
+# caller who sizes the window to its prompt, which capture does, defeats the fix and gets the raise.
+#
+# A floor rather than the number, because the number is not in the HF config: the per-item token
+# count comes from vLLM's processing info for that family (2496 on Gemma 4, 256 on Gemma 3), and
+# deriving it here would mean reimplementing each family's image-token math against a private API.
+# Generous enough for every multimodal family served so far; if one ever needs more, vLLM's refusal
+# names the value it wanted, which is the only honest way to revise this.
+MM_MIN_BATCHED_TOKENS = 8192
+
+
+def min_batched_tokens(config: Any) -> int | None:
+    """The ``max_num_batched_tokens`` this checkpoint cannot boot below, or ``None`` if unconstrained.
+
+    Companion to :func:`mandatory_kv_cache_dtype`, and here for the same reason: a boot requirement
+    every harness has to know is one the library should answer, not one each caller rediscovers from
+    a stack trace.
+
+    Keyed on the config being a multimodal wrapper rather than on the family, since the constraint
+    follows from having a non-text modality at all. Text-only checkpoints get ``None`` and keep
+    vLLM's own defaults, which is what makes this safe to ask about unconditionally.
+    """
+    return MM_MIN_BATCHED_TOKENS if config is not None and text_config(config) is not config else None
+
+
 # --- quantization and the backward pass ---------------------------------------
 #
 # Quantization is invisible to *capture*: hooks read activations, which transformers dequantizes to a

--- a/interp_engine/vllm_backend.py
+++ b/interp_engine/vllm_backend.py
@@ -1134,6 +1134,7 @@ class VLLMModel:
             ),
             n_layers=self.num_hidden_layers,
             tensor_parallel_size=self.tensor_parallel_size,
+            min_n=facts.min_batched_tokens(cfg) or 0,
         )
         if fitted != max_n:
             logger.warning("lowering max_num_batched_tokens %s -> %s so static buffers fit", max_n, fitted)

--- a/interp_engine/vllm_capture/static.py
+++ b/interp_engine/vllm_capture/static.py
@@ -544,6 +544,7 @@ def fit_max_num_batched_tokens(
     kv_width: int,
     n_layers: int,
     tensor_parallel_size: int = 1,
+    min_n: int = 0,
 ) -> int:
     """Largest capture size at or below ``max_n`` whose static buffers fit, or raise.
 
@@ -561,14 +562,20 @@ def fit_max_num_batched_tokens(
     The 1024 floor is for ``"auto"`` / default ``max_n``: vLLM will not usefully serve with a
     tiny batch. A caller who already passed a smaller ``max_n`` (chunked-prefill tests) keeps it
     when it fits.
+
+    ``min_n`` raises that floor to a size the *engine* will not start below, which is a different
+    kind of limit and has to outrank the fit: shrinking under it trades an out-of-memory error for a
+    refusal to boot, and the refusal comes from vLLM's scheduler talking about multimodal items,
+    which reads as anything but a static-buffer problem. Above the floor it changes nothing --
+    ``fitted == asked`` stays the common case. See :func:`interp_engine.facts.min_batched_tokens`.
     """
     graph_fudge = 3 * 1024**3
     tp = max(int(tensor_parallel_size), 1)
     min_kv = max(int(n_layers), 1) * max(int(max_model_len), 1) * max(int(kv_width), 1) * 2
     budget = int(gpu_memory_utilization * device_memory) - int(weight_bytes) // tp - graph_fudge - min_kv
     asked = int(max_n)
-    floor = min(1024, asked)
-    candidates = [asked] + [s for s in _CAPTURE_SIZES if s < asked]
+    floor = max(min(1024, asked), int(min_n))
+    candidates = [max(asked, floor)] + [s for s in _CAPTURE_SIZES if s < asked]
     for n in candidates:
         if n < floor:
             continue

--- a/tests/test_static_set.py
+++ b/tests/test_static_set.py
@@ -221,6 +221,33 @@ def test_vram_check_lowers_max_n_instead_of_ooming():
     assert fitted >= 1024
 
 
+def test_vram_check_will_not_shrink_below_an_engine_boot_floor():
+    """A multimodal prefix-LM will not start below one whole image, so shrinking under it is no fit.
+
+    Better to refuse here, naming the buffers, than to hand back a size vLLM rejects later with a
+    scheduler error about multimodal items that reads as anything but a static-buffer problem.
+    """
+
+    def fit(device_gib: int, **extra: int) -> int:
+        return fit_max_num_batched_tokens(
+            n_sites=80,
+            width=5120,
+            max_n=16384,
+            device_memory=device_gib * 1024**3,
+            gpu_memory_utilization=0.95,
+            weight_bytes=10 * 1024**3,
+            max_model_len=4096,
+            kv_width=kv_cache_width(d_model=5120),
+            n_layers=32,
+            **extra,
+        )
+
+    assert fit(20) == 4096  # left alone, this card shrinks under the floor
+    with pytest.raises(ValueError, match="do not fit even at max_num_batched_tokens=8192"):
+        fit(20, min_n=8192)
+    assert fit(24, min_n=8192) == 8192  # a floor it can meet changes nothing
+
+
 def test_vram_check_keeps_a_caller_max_n_below_the_1024_floor():
     """Chunked-prefill tests pass max_num_batched_tokens=32; skipping that candidate used to raise."""
     fitted = fit_max_num_batched_tokens(

--- a/validator/comparison/engines/vllm_engine.py
+++ b/validator/comparison/engines/vllm_engine.py
@@ -74,14 +74,20 @@ def _mandatory_engine_kwargs(hf_id: str) -> dict[str, object]:
     in a GPU test -- three harnesses this repo controls, and nowhere in the library a deployment
     imports, which is how a rule everyone here knew stayed missing from the thing shipped.
 
-    Only DeepSeek-V4 has one so far: it serves attention through `fp8_ds_mla`, a compressed-KV layout
-    that exists in FP8 only, so vLLM's default `auto` trips an assertion inside the model class after
-    the config work and before any weight is read.
+    Two so far. DeepSeek-V4 serves attention through `fp8_ds_mla`, a compressed-KV layout that exists
+    in FP8 only, so vLLM's default `auto` trips an assertion inside the model class after the config
+    work and before any weight is read.
 
     An FP8 KV cache is a numerics choice as well as a boot requirement, and this table is in the
     business of comparing numbers -- but it does not distort this cell: each capture is a single
     prefill of a 13-token prompt with `max_tokens=1`, so nothing is ever read back out of the KV
     cache. The activations being scored come from the forward itself.
+
+    The multimodal floor (`facts.min_batched_tokens`) is the one this harness provokes on itself. A
+    prefix-LM's whole image has to fit in one batch, and the `max_model_len` below is sized to the
+    13-token prompt, which is what drags vLLM's own batch default under the image and stops Gemma 4
+    booting. It distorts nothing either: the prompt carries no image, so a batch budget wide enough
+    for one changes what is allocated and not what is computed.
     """
     from interp_engine import facts
 
@@ -91,8 +97,14 @@ def _mandatory_engine_kwargs(hf_id: str) -> dict[str, object]:
         cfg = AutoConfig.from_pretrained(hf_id, trust_remote_code=True)
     except Exception:  # noqa: BLE001 - an unreadable config is the engine's problem to report
         return {}
+    kwargs: dict[str, object] = {}
     dtype = facts.mandatory_kv_cache_dtype(getattr(cfg, "architectures", None))
-    return {"kv_cache_dtype": dtype} if dtype else {}
+    if dtype:
+        kwargs["kv_cache_dtype"] = dtype
+    min_batched = facts.min_batched_tokens(cfg)
+    if min_batched:
+        kwargs["max_num_batched_tokens"] = min_batched
+    return kwargs
 
 
 def _d_model_points() -> frozenset[str]:


### PR DESCRIPTION
vLLM forces chunked multimodal input off for a model whose image tokens attend bidirectionally (Gemma 3, Gemma 4), and then refuses to start unless one whole item fits in a single batch. Both of this repo's vLLM paths size the batch to something smaller and hit the refusal:

  Chunked MM input disabled but max_tokens_per_mm_item (2496) is larger
  than max_num_batched_tokens (512).

vLLM raises its own floor for exactly this case, but only while defaulting `max_num_batched_tokens`, and clamps the result against `max_model_len` right after -- so a caller that sizes the window to its prompt defeats the fix.

* `facts.min_batched_tokens` names the requirement once, beside `mandatory_kv_cache_dtype`, which exists for the same reason: a boot rule every harness needs is the library's to answer, not each caller's to rediscover from a stack trace. Keyed on the config being a multimodal wrapper, so text-only checkpoints keep vLLM's defaults untouched.
* A floor rather than the real per-item count, because that count is not in the HF config -- it comes from vLLM's per-family processing info (2496 on Gemma 4, 256 on Gemma 3), and deriving it here would mean reimplementing each family's image-token math against a private API. vLLM names the value it wanted when a floor is ever too low.
* `fit_max_num_batched_tokens` takes `min_n` and will not shrink under it. A boot requirement has to outrank the buffer fit: below the floor the engine does not start at all, and it says so with a scheduler error about multimodal items that reads as anything but a static-buffer problem. Where both cannot be met it now raises here, naming the buffers and the fix.
* The comparison adapter asks for both kwargs, so its raw `vllm.LLM` boots the same checkpoints `VLLMModel` does -- which is the only thing that makes a Gemma 4 cell in the table worth reading.