### PR TITLE
fix(validator): bump nltk to 3.10.3 for the JVM argument injection bypass

### DIFF
--- a/validator/uv.lock
+++ b/validator/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1152,9 +1152,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/16/24d639531e73cbc6884fb251d116dfe469df9c595e0dcf24668c54d0e8d3/nltk-3.10.2.tar.gz", hash = "sha256:fcfd80fb77931868cea8357573c79838b8abc609942ef9914d1c9f6070d4645c", size = 3101716, upload-time = "2026-08-05T09:56:20.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/2b/bf677eb32ca6684b270c0d19ab133c2271e9f3375997e5a8dd2b08e3152d/nltk-3.10.2-py3-none-any.whl", hash = "sha256:2c7ccacb765c5e26b0cb60fb1b57080af522c6924d12a714a243305ba3637412", size = 1725815, upload-time = "2026-08-05T09:56:09.657Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the one **critical** Dependabot alert on `main`, plus the **high** sitting beside it. Both are the same package and the same bump.

| Advisory | Severity | Fixed in |
| --- | --- | --- |
| [GHSA-m4rf-3fr8-xwx3](https://github.com/advisories/GHSA-m4rf-3fr8-xwx3) | critical | 3.10.3 |
| [GHSA-6hwm-xvph-95vm](https://github.com/advisories/GHSA-6hwm-xvph-95vm) | high | 3.10.3 |

## What the critical one is

An incomplete fix of CVE-2026-12841. `_validate_java_options()` blocks `-javaagent`, `-agentpath`, `-Xrunjdwp` and `@argfile` when options are set globally through `config_java()`, but the per-call `options` argument on `java()` — added by the CVE-2026-12615 fix — is handed to `subprocess.Popen` without ever reaching that validator. All four Stanford Java wrappers accept user-supplied `java_options` and route them down the unvalidated path, so the earlier fix is bypassed end to end.

## Why the change is only a lock file

`nltk` reaches the validator transitively, through `sae-lens`. It is not named in `validator/pyproject.toml`, so the lock is the only place to move it.

## Scope

One package, three lines. `uv lock --upgrade-package nltk` produced no collateral resolution changes — 157 packages resolved, one moved.

Worth being plain about the real exposure: nothing in this repository imports `nltk`, so the Stanford wrappers are never reached and this closes an alert rather than an exploited hole. It is still worth taking, because a one-line lock bump costs nothing to carry and a critical alert on `main` is noise that hides the next one.

## Test plan

- [x] `uv lock --check` in `validator/` — resolves clean, no drift
- [x] Diff confined to the `nltk` entry in `validator/uv.lock`
- [x] Confirmed no source in the repo imports `nltk`, `config_java`, or any Stanford wrapper
- [x] pre-push hook: ruff, both pyright configs, validator pyright, visualizer checks
- [ ] CI green

## Left for follow-up

Seven open alerts remain, none critical: `image-size` (2 high, npm, `visualizer-web/docs-site`, **no patched version published yet**), `pytest` (medium, both locks), `setuptools` (medium, root lock), `torch` (low, root lock). The `pytest` and `setuptools` bumps touch the root lock and so the published wheel's resolution, which is a wider blast radius than this PR should carry.

Made with [Cursor](https://cursor.com)