### PR TITLE
chore: let Dependabot open the bumps instead of waiting to be noticed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+# Who bumps the dependencies, so that nobody has to notice.
+#
+# Alerts were already on before this file existed, which is a strictly worse arrangement than it
+# sounds: GitHub told us about a critical advisory on every single push and then did nothing about
+# it, so the banner became furniture and the fix waited for someone to read it. Alerts are the
+# detector; this file and the "Dependabot security updates" repository setting are the response.
+# Turning one on without the other is how an advisory sits on `main` for weeks.
+#
+# **Four manifests, in three ecosystems.** The engine and the validator are separate uv projects
+# with separate locks, and the visualizer's app and its docs site are separate npm projects. Every
+# one of them has to be named here or it is simply not watched -- the validator's lock is where the
+# nltk advisory lived, and it is the furthest from anything anyone opens.
+#
+# **Why the two uv directories share one entry.** `group-by: dependency-name` puts a dependency's
+# bump in a single pull request across both locks rather than one per directory. That is not tidiness:
+# `validator/` keeps its ruff and pyright configuration verbatim identical to the root's, and CI has
+# a parity job that fails when they drift. A tool bumped in one lock and not the other reformats code
+# on one side of that boundary and not the other, so the two locks have to move together.
+#
+# **These land on `main`, and every push to `main` is a candidate release.** The commit subject picks
+# the bump (see AGENTS.md), and `chore(deps)` is not `feat:`, so these cut a patch rather than a
+# minor. Left at Dependabot's default subject they would follow no convention at all and still cut a
+# patch -- the prefix is here to make that a decision rather than a coincidence.
+
+version: 2
+
+updates:
+  # Python: the engine at the root and the validator beside it.
+  - package-ecosystem: "uv"
+    directories:
+      - "/"
+      - "/validator"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      python:
+        group-by: "dependency-name"
+        patterns:
+          - "*"
+
+  # JavaScript: the visualizer app and the docs site it links to.
+  - package-ecosystem: "npm"
+    directories:
+      - "/visualizer-web"
+      - "/visualizer-web/docs-site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      javascript:
+        group-by: "dependency-name"
+        patterns:
+          - "*"
+
+  # The workflows themselves. `/` is correct here and does not mean the repository root: for Actions
+  # it is the spelling that makes Dependabot read `.github/workflows`.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Follow-up to [#5](https://github.com/decoderesearch/interp-engine/pull/5). That PR fixed one advisory by hand; this one is so the next hand is not needed.

## The actual gap

Dependabot **alerts** were on. Dependabot **security updates** were off. That combination is worse than it sounds: GitHub printed `1 critical` on every push to this repo and then opened nothing about it, so the line became furniture and the fix waited for a person to read a banner they had learned to skip. `nltk` sat in `validator/uv.lock` until someone happened to look.

Two halves, and both are now on:

- **The repository setting** (`Dependabot security updates`) — enabled. This is what opens a PR the day an advisory lands. It is not configurable from `dependabot.yml` and was the missing piece.
- **This file** — schedules the routine weekly version updates, so dependencies drift less and the security bump is a small diff rather than a leap.

## What is watched

Four manifests across three ecosystems. Each has to be named or it is simply not watched:

| Ecosystem | Directories |
| --- | --- |
| `uv` | `/`, `/validator` |
| `npm` | `/visualizer-web`, `/visualizer-web/docs-site` |
| `github-actions` | `/` |

`validator/uv.lock` is the one that mattered here and is the furthest from anything anyone opens day to day.

## Two choices worth explaining

**The uv directories share one entry.** `group-by: dependency-name` puts a dependency's bump in one PR spanning both locks instead of one PR per directory. That is not tidiness. `validator/` keeps its ruff and pyright configuration verbatim identical to the root's and CI has a parity job that fails on drift, so a formatter bumped in one lock and not the other reformats one side of that boundary and not the other.

**`chore(deps)` prefix.** Every push to `main` is a candidate release and the commit subject picks the bump. `chore(deps)` cuts a patch. Left at Dependabot's default subject these would follow no convention and cut a patch anyway — the prefix makes that a decision rather than a coincidence.

## Heads-up: this will open PRs

Enabling security updates against the 7 remaining open alerts will raise PRs shortly, and the weekly version-update run will add more. Expect, roughly:

- `pytest` → 9.0.3 (medium, both locks)
- `setuptools` → 83.0.0 (medium, root lock)
- `torch` → 2.13.0 (low, root lock — worth reviewing rather than rubber-stamping)
- `image-size` (2 high, docs-site) — **no patched version exists yet**, so nothing will open until one does

Caps are set at 5 open PRs per ecosystem so this cannot run away. If the volume is wrong, the dial is `open-pull-requests-limit`, and the setting is one API call to switch back off.

## Test plan

- [x] YAML parses; ecosystems and directories resolve as intended
- [x] Every manifest in the repo is covered by an entry
- [x] Security updates setting confirmed enabled via the API
- [ ] Dependabot validates the config on merge (Insights → Dependency graph → Dependabot)
- [ ] First scheduled run opens sane PRs

Made with [Cursor](https://cursor.com)