### PR TITLE
fix(capture): move a caller's token ids onto the device before the forward

### DIFF
--- a/interp_engine/capture.py
+++ b/interp_engine/capture.py
@@ -224,7 +224,10 @@ def _run_with_cache_eager(
     attention_mask: torch.Tensor | None = None,
 ) -> Cache:
     """Capture in-process off the live module tree. See :func:`run_with_cache`."""
-    input_ids = as_batched_tokens(tokens)
+    # Placed here rather than by each caller: these ids go straight into `hf_model`, so a list or a
+    # host tensor -- both documented inputs -- fails on every accelerator otherwise, through either
+    # entry point that shares this body. A tensor already on the device is unmoved.
+    input_ids = as_batched_tokens(tokens, device=model.device)
     addresses = _normalize_points(points)
     cache = Cache()
 

--- a/tests/test_unified_free_functions.py
+++ b/tests/test_unified_free_functions.py
@@ -8,6 +8,7 @@ checked against these same shapes by ``scripts/vllm_capture_generation_check.py`
 
 import asyncio
 
+import pytest
 import torch
 
 from interp_engine import (
@@ -73,6 +74,29 @@ def test_capture_attention_returns_scores_probs_and_per_head_value(gpt2: EagerMo
         assert got[layer]["scores"].shape == (gpt2.n_heads, seq, seq)
         assert got[layer]["probs"].shape == (gpt2.n_heads, seq, seq)
         assert got[layer]["value"].shape == (seq, gpt2.n_kv_heads, gpt2.head_dim)
+
+
+def test_every_eager_entry_point_takes_a_plain_list_of_ids(gpt2: EagerModel, prompt: str):
+    """A list of ints is a documented input, and it is the one that used to reach the device wrong.
+
+    The tests around this one all pass ``to_tokens`` output, a tensor already on the model's device,
+    so the host tensor a list builds was never exercised and both functions below raised on any
+    accelerator. ``EagerModel.capture`` hid it by placing its own tensor. On a CPU box both arms are
+    the same tensor and this only pins the signature; the device half is the gpu test below.
+    """
+    ids = [int(t) for t in gpt2.to_tokens(prompt)[0]]
+    assert sorted(capture_attention(gpt2, ids, [0])) == [0]
+    assert run_with_cache(gpt2, ids, [("resid_post", 0)]).get("resid_post", 0).shape[1] == len(ids)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="a host tensor only misplaces on an accelerator")
+def test_a_list_of_ids_reaches_the_accelerator(prompt: str):
+    """The regression itself: ids built off-device must be moved before they reach ``hf_model``."""
+    model = EagerModel("openai-community/gpt2", device="cuda", attn_implementation="eager")
+    ids = [int(t) for t in model.to_tokens(prompt)[0]]
+    assert capture_attention(model, ids, [0])[0]["scores"].device.type == "cuda"
+    assert run_with_cache(model, ids, [("resid_post", 0)]).get("resid_post", 0).device.type == "cuda"
 
 
 def test_capture_attention_agrees_with_the_points_it_is_built_from(gpt2: EagerModel, prompt: str):


### PR DESCRIPTION
## What breaks today

`_run_with_cache_eager` builds its `[batch, seq]` token tensor with no device:

```python
input_ids = as_batched_tokens(tokens)
```

So token ids that arrive as **a list of ints or as a host tensor** stay on the host and the forward
raises on any accelerator. A list is a documented input — `run_with_cache`'s own docstring says
"tensor, or a list of ids", and the 1.1 migration table in `docs/AGENT_INTEGRATION.md` advertises
it as a new capability — so this was a promise that only held on CPU.

Measured on an RTX 5090, reverting the fix to get the before column:

| Entry point | Before | After |
| --- | --- | --- |
| `run_with_cache(list)` | fails | passes |
| `run_with_cache(host tensor)` | fails | passes |
| `run_with_cache(device tensor)` | passes | passes |
| `capture_attention(list)` | fails | passes |
| `capture_attention(host tensor)` | fails | passes |
| `EagerModel.capture(list)` | passes | passes |

```
RuntimeError: Expected all tensors to be on the same device, but got index is on cpu,
different from other tensors on cuda:0
```

Reproduces identically on Apple silicon / MPS.

## Scope

**Eager only.** vLLM goes through `_run_with_cache_via_protocol` and was never affected. CPU was
never affected, since the host tensor is already in the right place.

Both eager entry points that share this body are hit: `run_with_cache` and `capture_attention`
(the free function and `EagerModel.capture_attention`, which delegates to `capture_attention_eager`).

## The fix

One line, in the shared body rather than at each caller. `main` already has the `device=` keyword
on `as_batched_tokens`; this only starts using it. A tensor already on the device is unmoved.

## Why no test caught it

Every test around these two passes `to_tokens` output, which is already placed. And
`EagerModel.capture` — the neighbour you would naturally compare against — builds its own tensor
with `device=self.device`, so the two looked inconsistent for no visible reason.

Two tests added: one portable, pinning that both functions accept a list, and one `gpu`-marked that
asserts the results come back on the accelerator. I verified the second fails against `main`'s
`capture.py` and passes with the fix, so it pins the bug rather than passing incidentally.

## Checks

`ruff format --check`, `ruff check`, pyright (0 errors), and 2244 CPU tests pass; the `gpu`
regression test passes on a 5090.

## Note for the release workflow

`interp_engine/capture.py` is a packaged file, so `make release-plan` reads **v1.7.2 (patch)** —
merging this cuts a release on its own.

Made with [Cursor](https://cursor.com)